### PR TITLE
Fix code signing for Developer ID distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
             MARKETING_VERSION=${{ steps.version.outputs.version }} \
             CURRENT_PROJECT_VERSION=${{ github.run_number }} \
             DEVELOPMENT_TEAM="$DEVELOPMENT_TEAM" \
-            CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_STYLE=Manual \
             CODE_SIGN_IDENTITY="Developer ID Application" \
             ONLY_ACTIVE_ARCH=NO
 
@@ -108,7 +108,7 @@ jobs:
               <key>teamID</key>
               <string>${{ secrets.DEVELOPMENT_TEAM }}</string>
               <key>signingStyle</key>
-              <string>automatic</string>
+              <string>manual</string>
               <key>signingCertificate</key>
               <string>Developer ID Application</string>
           </dict>


### PR DESCRIPTION
## Summary
- Changed `CODE_SIGN_STYLE` from `Automatic` to `Manual` in xcodebuild archive step
- Changed `signingStyle` from `automatic` to `manual` in ExportOptions.plist

## Problem
`CODE_SIGN_STYLE=Automatic` conflicts with `Developer ID Application` identity, causing build failure:
```
error: VoiceClaudePoC has conflicting provisioning settings. 
VoiceClaudePoC is automatically signed for development, but a conflicting 
code signing identity Developer ID Application has been manually specified.
```

## Solution
For Developer ID distribution (notarized, outside App Store), we need Manual signing style. No provisioning profile is required.

## Test plan
- [ ] Trigger workflow manually and verify build succeeds
- [ ] Verify app is properly signed and notarized

🤖 Generated with [Claude Code](https://claude.com/claude-code)